### PR TITLE
Update axe-core and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Dylan Barrell (dylan@barrell.com)",
   "license": "MPL-2.0",
   "dependencies": {
-    "axe-core": "~2.2.3"
+    "axe-core": "~2.3.1"
   },
   "devDependencies": {
     "eslint": "~3.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-axe",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@dylanb I wasn't sure if this should be a patch or minor version, so I updated it to 2.1.7. We can bump to 2.2.0 if you think that's more appropriate. I suppose you can turn on the new experimental rules in the config.