### PR TITLE
FIX: addComponent was getting called for the same component multiple …

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function componentAfterRender(component) {
 }
 
 function addComponent(component) {
-  var reactInstance = component._reactInternalInstance;
+	var reactInstance = component._reactInternalInstance;
 	if (reactInstance && !components[reactInstance._debugID]) {
 		components[reactInstance._debugID] = component;
 		componentAfterRender(component);

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function getCommonParent(nodes) {
 			});
 		}
 	}
-	return path[path.length - 1];
+	return path ? path[path.length - 1] : document;
 }
 
 function logElement(node, logFn) {
@@ -186,7 +186,8 @@ function componentAfterRender(component) {
 }
 
 function addComponent(component) {
-	if (component._reactInternalInstance) {
+  var reactInstance = component._reactInternalInstance;
+	if (reactInstance && !components[reactInstance._debugID]) {
 		components[component._reactInternalInstance._debugID] = component;
 		componentAfterRender(component);
 	}

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function componentAfterRender(component) {
 function addComponent(component) {
   var reactInstance = component._reactInternalInstance;
 	if (reactInstance && !components[reactInstance._debugID]) {
-		components[component._reactInternalInstance._debugID] = component;
+		components[reactInstance._debugID] = component;
 		componentAfterRender(component);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "cypress": "^2.1.0",
-    "eslint": "^4.13.1",
+    "eslint": "^5.0.0",
     "http-server": "^0.11.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
…times causing after.js be added many times

For some of our components the addComponent function was getting called multiple times. Because of this the after hook would replace the component function with another after hook. This would cause the checkAndReport function to be called many times for the same component and eventually build up to #19. This diff checks to see if we have already added and after hook to the component before we add one.
 
Closes issue: #19 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @dylanb
