### PR TITLE
ci: auto-publish "master" commits

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,52 +6,34 @@ defaults: &defaults
     - image: cypress/base:6
   working_directory: ~/react-axe
 
-restore_dependency_cache: &restore_dependency_cache
-  restore_cache:
-    keys:
-      - v1-npm-cache-{{ checksum "package-lock.json" }}
-      - v1-npm-cache-
-
-restore_example_dependency_cache: &restore_example_dependency_cache
-  restore_cache:
-    keys:
-      - v1-npm-example-cache-{{ checksum "example/package.json" }}
-      - v1-npm-example-cache-
-
-set_npm_auth: &set_npm_auth
-  run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
-
 jobs:
   # Fetch and cache dependencies.
   dependencies:
     <<: *defaults
     steps:
       - checkout
-      - <<: *set_npm_auth
-      - <<: *restore_dependency_cache
-      - <<: *restore_example_dependency_cache
+      - restore_cache:
+          keys:
+            - v1-cache-{{ checksum "package-lock.json" }}
       # Install package dependencies.
       - run: npm install
-      - save_cache:
-          key: v1-npm-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-            # Cypress cache
-            - ~/.cache
       # Install example dependencies; they're used in tests.
       - run: npm install --prefix example
       - save_cache:
-          key: v1-npm-example-cache-{{ checksum "example/package.json" }}
+          key: v1-cache-{{ checksum "package-lock.json" }}
           paths:
+            - node_modules
             - example/node_modules
+            - ~/.cache
 
   # Run the test suite.
   test:
     <<: *defaults
     steps:
       - checkout
-      - <<: *restore_dependency_cache
-      - <<: *restore_example_dependency_cache
+      - restore_cache:
+          keys:
+            - v1-cache-{{ checksum "package-lock.json" }}
       - run: npm run test
 
   # Release a new version.
@@ -59,8 +41,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - <<: *set_npm_auth
-      - <<: *restore_dependency_cache
+      - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+      - restore_cache:
+          keys:
+            - v1-cache-{{ checksum "package-lock.json" }}
       - run: npm publish
 
 workflows:

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,8 @@ restore_dependency_cache: &restore_dependency_cache
     keys:
       - v1-npm-cache-{{ checksum "package-lock.json" }}
       - v1-npm-cache-
+  restore_cache:
+    keys:
       - v1-npm-example-cache-{{ checksum "example/package.json" }}
       - v1-npm-example-cache-
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,29 +1,69 @@
 version: 2
 
+defaults: &defaults
+  docker:
+    # Use a Docker image with Cypress already installed.
+    - image: cypress/base:6
+  working_directory: ~/react-axe
+
+restore_dependency_cache: &restore_dependency_cache
+  restore_cache:
+    keys:
+      - v1-npm-cache-{{ checksum "package-lock.json" }}
+      - v1-npm-cache-
+      - v1-npm-example-cache-{{ checksum "example/package-lock.json" }}
+      - v1-npm-example-cache-
+
+set_npm_auth: &set_npm_auth
+  run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+
 jobs:
-  build:
-    docker:
-      # the Docker image with Cypress dependencies
-      - image: cypress/base:6
-        environment:
-          # this enables colors in the output
-          TERM: xterm
-    working_directory: ~/app
-    parallelism: 1
+  # Fetch and cache dependencies.
+  dependencies:
+    <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-npm-deps-{{ checksum "package-lock.json" }}
-            - v1-npm-deps
-      - run:
-          name: Install top-level dependencies
-          command: npm install
-      - run:
-          name: Install example dependencies
-          command: cd example && npm install
+      - <<: *set_npm_auth
+      - <<: *restore_dependency_cache
+      - run: npm install
       - save_cache:
-          key: v1-npm-deps-{{ checksum "package-lock.json" }}
+          key: v1-npm-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      # Install example dependencies; they're used in tests.
+      - run: npm install --prefix example
+
+  # Run the test suite.
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *restore_dependency_cache
       - run: npm run test
+
+  # Release a new version.
+  production_release:
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *set_npm_auth
+      - <<: *restore_dependency_cache
+      - run: npm publish
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - dependencies
+      # Run tests on all commits, but after installing dependencies.
+      - test:
+          requires:
+            - dependencies
+      # Run a production release on "master" commits, but only after the tests pass and dependencies are installed.
+      - production_release:
+          requires:
+            - dependencies
+            - test
+          filters:
+            branches:
+              only: master

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,8 @@ jobs:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+            # Cypress cache
+            - ~/.cache
       # Install example dependencies; they're used in tests.
       - run: npm install --prefix example
       - save_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ restore_dependency_cache: &restore_dependency_cache
     keys:
       - v1-npm-cache-{{ checksum "package-lock.json" }}
       - v1-npm-cache-
-      - v1-npm-example-cache-{{ checksum "example/package-lock.json" }}
+      - v1-npm-example-cache-{{ checksum "example/package.json" }}
       - v1-npm-example-cache-
 
 set_npm_auth: &set_npm_auth
@@ -32,6 +32,10 @@ jobs:
             - node_modules
       # Install example dependencies; they're used in tests.
       - run: npm install --prefix example
+      - save_cache:
+          key: v1-npm-cache-{{ checksum "example/package.json" }}
+          paths:
+            - example/node_modules
 
   # Run the test suite.
   test:

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,8 @@ restore_dependency_cache: &restore_dependency_cache
     keys:
       - v1-npm-cache-{{ checksum "package-lock.json" }}
       - v1-npm-cache-
+
+restore_example_dependency_cache: &restore_example_dependency_cache
   restore_cache:
     keys:
       - v1-npm-example-cache-{{ checksum "example/package.json" }}
@@ -27,6 +29,7 @@ jobs:
       - checkout
       - <<: *set_npm_auth
       - <<: *restore_dependency_cache
+      - <<: *restore_example_dependency_cache
       - run: npm install
       - save_cache:
           key: v1-npm-cache-{{ checksum "package-lock.json" }}
@@ -45,6 +48,7 @@ jobs:
     steps:
       - checkout
       - <<: *restore_dependency_cache
+      - <<: *restore_example_dependency_cache
       - run: npm run test
 
   # Release a new version.


### PR DESCRIPTION
This patch updates our CircleCI configuration, enabling auto-publishing all (green) "master" commits to npm. This expects the developer merging "develop" into "master" has incremented `package.json#version` appropriately, updated the `CHANGELOG.md`, etc.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu
