### PR TITLE
fix: look for debug id under the fibre if not in the internal instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,9 +203,19 @@ function componentAfterRender(component) {
 }
 
 function addComponent(component) {
-  var reactInstance = component._reactInternalInstance;
-  if (reactInstance && !components[reactInstance._debugID]) {
-    components[reactInstance._debugID] = component;
+  var reactInstance = component._reactInternalInstance || {};
+  var reactInstanceDebugID = reactInstance._debugID;
+  var reactFiberInstance = component._reactInternalFiber || {};
+  var reactFiberInstanceDebugID = reactFiberInstance._debugID;
+
+  if (reactInstanceDebugID && !components[reactInstanceDebugID]) {
+    components[reactInstanceDebugID] = component;
+    componentAfterRender(component);
+  } else if (
+    reactFiberInstanceDebugID &&
+    !components[reactFiberInstanceDebugID]
+  ) {
+    components[reactFiberInstanceDebugID] = component;
     componentAfterRender(component);
   }
 }


### PR DESCRIPTION
For React 16 the debugID does not appear under `component._reactInternalInstance._debugID` anymore and is instead under `component._reactInternalFiber._debugID`. If we don't find a debugID under the internal instance we instead look inside the fiber instance. I've tested this out with a single page app I work on and seems to behave correctly.

Closes issue: https://github.com/dequelabs/react-axe/issues/58

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Adam Cutler
