### PR TITLE
FIX: include node tested to its path when determining commonParent

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var nodes = [];
 var cache = {};
 
 function getPath(node) {
-  var path = [];
+  var path = [node];
   do {
     path.push(node.parentNode);
     node = node.parentNode;

--- a/index.js
+++ b/index.js
@@ -20,15 +20,15 @@ var idleId;
 var timeout;
 var _createElement;
 var components = {};
-var nodes = [];
+var nodes = [document.documentElement];
 var cache = {};
 
 function getPath(node) {
   var path = [node];
-  do {
+  while (node && node.nodeName.toLowerCase() !== 'html') {
     path.push(node.parentNode);
     node = node.parentNode;
-  } while (node && node.nodeName.toLowerCase() !== 'html');
+  }
   if (!node || !node.parentNode) {
     return null;
   }


### PR DESCRIPTION
One of our engineers reported react-axe causing their page to hang when they hovered over certain buttons. 

<img width="521" alt="Before" src="https://user-images.githubusercontent.com/30501355/57494533-91daeb80-727e-11e9-8e1c-3369dc5552e9.png">
This is a performance capture of me hovering the button 3 times. It takes ~1.3 seconds per `axe.run` call.
<br/><br/>

After digging in, it looks like the issue was a combination of: 

1. The \<button\>s were one level away from a \<main\> container which included many elements
2. the paths being compared in getCommonParent don't include the nodes in the audit list so, even if one node is in the list, the function would always return the node at least one level up

This change just includes the root node being checked to the getPath function so that we can save the extra level of hierarchy when running the axe audits.

![After](https://user-images.githubusercontent.com/30501355/57494580-d2d30000-727e-11e9-969b-0f79f5ed3172.png)
With the change, hovering the same button 3 times. Each run of `axe.run` takes ~45ms

This fix won't have as dramatic results for every case but it should add at least a small speed up across the board and really help when interacting with elements one level away from large containing elements.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
