### PR TITLE
catch and log errors thrown when calling React.findDOMNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,10 +197,10 @@ function checkNode(component) {
   } catch (e) {
     console.group('%caXe error: could not check node', critical);
     console.group('%cComponent', serious);
-    console.log(component);
+    console.error(component);
     console.groupEnd();
     console.group('%cError', serious);
-    console.log(e);
+    console.error(e);
     console.groupEnd();
     console.groupEnd();
   }

--- a/index.js
+++ b/index.js
@@ -190,7 +190,20 @@ function checkAndReport(node, timeout) {
 }
 
 function checkNode(component) {
-  var node = ReactDOM.findDOMNode(component);
+  var node = null;
+
+  try {
+    node = ReactDOM.findDOMNode(component);
+  } catch (e) {
+    console.group('%caXe error: could not check node', critical);
+    console.group('%cComponent', serious);
+    console.log(component);
+    console.groupEnd();
+    console.group('%cError', serious);
+    console.log(e);
+    console.groupEnd();
+    console.groupEnd();
+  }
 
   if (node) {
     checkAndReport(node, timeout);


### PR DESCRIPTION
This is mainly a band-aid so that exceptions thrown when checking a DOM node don't crash a React app. It logs the offending component and error to the console.

Given how the library hooks itself into the component lifecycle, I didn't want to try and remove the use of `findDOMNode` entirely, even though it is deprecated in the newer releases of React/ReactDOM. At a glance, that looks like it will be rather non-trivial to change how react-axe listens for component updates.

Closes issue: #74 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen