### PR TITLE
fix(example): correctly mount shadow DOM

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,5 @@
 {
   "fileServerFolder": "example",
   "pluginsFile": false,
-  "supportFile": false,
   "video": false
 }

--- a/cypress/integration/index-test.js
+++ b/cypress/integration/index-test.js
@@ -38,26 +38,20 @@ describe('React-axe', function() {
     });
   });
 
-  it('should run axe inside of Shadow DOM', function() {
-    cy.visit('http://localhost:8080').then(function(win) {
-      const groupCollapsed = cy.spy(win.console, 'groupCollapsed');
-      const colorMessage = 'Elements must have sufficient color contrast';
+  it('should run axe inside of Shadow DOM', async function() {
+    const win = await cy.visit('http://localhost:8080');
+    const groupCollapsed = cy.spy(win.console, 'groupCollapsed');
+    const colorMessage = 'Elements must have sufficient color contrast';
 
-      let serviceChooser;
-      cy.get('service-chooser')
-        .first()
-        .then(function(node) {
-          serviceChooser = node[0];
-        });
+    const node = await cy.get('service-chooser').first();
+    const serviceChooser = node[0];
 
-      axe(React, ReactDOM, 0).then(function() {
-        expect(filterLogs(groupCollapsed.args, colorMessage)).to.equal(
-          colorMessage
-        );
-        expect(filterLogs(groupCollapsed.args, serviceChooser)).to.equal(
-          serviceChooser
-        );
-      });
-    });
+    await axe(React, ReactDOM, 0);
+    expect(filterLogs(groupCollapsed.args, colorMessage)).to.equal(
+      colorMessage
+    );
+    expect(filterLogs(groupCollapsed.args, serviceChooser)).to.equal(
+      serviceChooser
+    );
   });
 });

--- a/cypress/integration/index-test.js
+++ b/cypress/integration/index-test.js
@@ -38,20 +38,27 @@ describe('React-axe', function() {
     });
   });
 
-  it('should run axe inside of Shadow DOM', async function() {
-    const win = await cy.visit('http://localhost:8080');
-    const groupCollapsed = cy.spy(win.console, 'groupCollapsed');
-    const colorMessage = 'Elements must have sufficient color contrast';
+  it('should run axe inside of Shadow DOM', function() {
+    cy.visit('http://localhost:8080').then(function(win) {
+      const groupCollapsed = cy.spy(win.console, 'groupCollapsed');
+      const colorMessage = 'Elements must have sufficient color contrast';
 
-    const node = await cy.get('service-chooser').first();
-    const serviceChooser = node[0];
+      let serviceChooser;
+      cy.document()
+        .shadowGet('#service-chooser')
+        .shadowFirst()
+        .then(function(node) {
+          serviceChooser = node[0];
+        });
 
-    await axe(React, ReactDOM, 0);
-    expect(filterLogs(groupCollapsed.args, colorMessage)).to.equal(
-      colorMessage
-    );
-    expect(filterLogs(groupCollapsed.args, serviceChooser)).to.equal(
-      serviceChooser
-    );
+      axe(React, ReactDOM, 0).then(function() {
+        expect(filterLogs(groupCollapsed.args, colorMessage)).to.equal(
+          colorMessage
+        );
+        expect(filterLogs(groupCollapsed.args, serviceChooser)).to.equal(
+          serviceChooser
+        );
+      });
+    });
   });
 });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,1 @@
+import 'cypress-shadow-dom';

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "axe-core": "^3.0.0-beta.1",
     "create-react-class": "^15.6.3",
-    "react": "^16.2.0",
+    "react": "^16.8.6",
     "react-dom": "^16.2.0",
     "react-shadow": "^17.0.0",
     "webcomponents.js": "^0.7.24"

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "axe-core": "^3.0.0-beta.1",
     "create-react-class": "^15.6.3",
     "react": "^16.8.6",
-    "react-dom": "^16.2.0",
+    "react-dom": "^16.8.6",
     "react-shadow": "^17.0.0",
     "webcomponents.js": "^0.7.24"
   },

--- a/example/src/serviceChooser.js
+++ b/example/src/serviceChooser.js
@@ -28,7 +28,7 @@ module.exports = createReactClass({
       );
     });
     return (
-      <ShadowDOM>
+      <ShadowDOM.div>
         <service-chooser>
           <div id="services">
             {services}
@@ -38,7 +38,7 @@ module.exports = createReactClass({
           </div>
           <style type="text/css">{styles}</style>
         </service-chooser>
-      </ShadowDOM>
+      </ShadowDOM.div>
     );
   }
 });

--- a/example/src/serviceChooser.js
+++ b/example/src/serviceChooser.js
@@ -28,16 +28,14 @@ module.exports = createReactClass({
       );
     });
     return (
-      <ShadowDOM.div>
-        <service-chooser>
-          <div id="services">
-            {services}
-            <p id="total">
-              Total <b>${this.state.total.toFixed(2)}</b>
-            </p>
-          </div>
-          <style type="text/css">{styles}</style>
-        </service-chooser>
+      <ShadowDOM.div id="service-chooser">
+        <div id="services">
+          {services}
+          <p id="total">
+            Total <b>${this.state.total.toFixed(2)}</b>
+          </p>
+        </div>
+        <style type="text/css">{styles}</style>
       </ShadowDOM.div>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,6 +985,12 @@
         "yauzl": "2.8.0"
       }
     },
+    "cypress-shadow-dom": {
+      "version": "0.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/cypress-shadow-dom/-/cypress-shadow-dom-0.1.0.tgz",
+      "integrity": "sha1-rkib8Bz52+j1Aq3H4tGt5Qj6ODg=",
+      "dev": true
+    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4257,25 +4257,37 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha1-oXsqfKie5zkLwe1euBeDx0YXSLg=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.6"
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha1-BdXKd7RFPphdYPx/+MhZCUpJcQI=",
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
           }
         }
       }
@@ -4526,9 +4538,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha1-irF2mZOcCu3FoZamV3Q8SWU4ZHs=",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4211,24 +4211,46 @@
       "dev": true
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/react/-/react-16.7.0.tgz",
-      "integrity": "sha1-tnTsOWsKVxWHOzUERvfqCAKrY4E=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.6"
       },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha1-BdXKd7RFPphdYPx/+MhZCUpJcQI=",
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.3.1",
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        },
+        "scheduler": {
+          "version": "0.13.6",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+          "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
         }
@@ -4257,6 +4279,12 @@
           }
         }
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "cypress": "^3.0.3",
+    "cypress-shadow-dom": "^0.1.0",
     "eslint": "^5.0.0",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-plugin-import": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "husky": "^2.0.0",
     "lint-staged": "^8.1.0",
     "prettier": "^1.15.3",
-    "react": "^16.7.0",
+    "react": "^16.8.6",
     "react-dom": "^16.7.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint-staged": "^8.1.0",
     "prettier": "^1.15.3",
     "react": "^16.8.6",
-    "react-dom": "^16.7.0"
+    "react-dom": "^16.8.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch updates the example to properly mount the shadow DOM container. This was caused by https://github.com/dequelabs/react-axe/pull/83 landing.

I do not understand why https://github.com/dequelabs/react-axe/pull/83 passed CI, nor why testing that branch locally worked. :man_shrugging:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @AutoSponge (and @stephenmathieson)