### PR TITLE
chore: add postinstall hook to install example dir needed for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
             - v2-example-cache-{{ checksum "example/package.json" }}
       # Install package dependencies.
       - run: npm install
-      # Install example dependencies; they're used in tests.
-      - run: npm install --prefix example
       - save_cache:
           key: v2-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/README.md
+++ b/README.md
@@ -73,19 +73,10 @@ npm start
 
 ## Run the tests
 
-Install dependencies in the example app and then run Cypress in the root directory of react-axe.
+Install dependencies in the root directory (which also installs them in the example directory) and then run the tests:
 
 ```
-cd example
 npm install
-cd ../
-npm install
-npm test
-```
-
-Once you’ve installed everything at least once, you can just run the tests:
-
-```
 npm test
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,12 +248,6 @@
         "commander": "^2.11.0"
       }
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -277,12 +271,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
@@ -461,23 +449,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
-      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -710,15 +681,6 @@
         "which": "^1.2.9"
       }
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
-    },
     "cypress": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.0.tgz",
@@ -803,30 +765,6 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "dev": true,
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
-      }
-    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -882,12 +820,6 @@
       "version": "1.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "detect-indent": {
-      "version": "5.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
     "doctrine": {
@@ -2402,12 +2334,6 @@
         "path-is-inside": "^1.0.1"
       }
     },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-promise/-/is-promise-2.1.0.tgz",
@@ -3106,12 +3032,6 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
-    "lodash.mapkeys": {
-      "version": "4.6.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
-      "integrity": "sha1-3yz6Ix18V8eorQA6va1dc9PqUZU=",
-      "dev": true
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -3144,125 +3064,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
-    },
-    "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-      "dev": true
-    },
-    "meow": {
-      "version": "5.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        }
       }
     },
     "merge-stream": {
@@ -3322,16 +3123,6 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
-    },
-    "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
-      }
     },
     "mkdirp": {
       "version": "0.5.0",
@@ -3704,61 +3495,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pinst": {
-      "version": "1.1.1",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pinst/-/pinst-1.1.1.tgz",
-      "integrity": "sha1-1aE5YR5TzpeFJdi2qjX++h97JgE=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^5.0.0",
-        "lodash.mapkeys": "^4.6.0",
-        "meow": "^5.0.0",
-        "write-json-file": "^2.3.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/graceful-fs/-/graceful-fs-4.2.0.tgz",
-          "integrity": "sha1-jY/cc5d8sEEEchy1NmbBymTNMos=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "5.3.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/load-json-file/-/load-json-file-5.3.0.tgz",
-          "integrity": "sha1-TTweAfocA+p4pgrHr5MsnOU0A/M=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "parse-json": "^4.0.0",
-            "pify": "^4.0.1",
-            "strip-bom": "^3.0.0",
-            "type-fest": "^0.3.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.3.1",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha1-Y9ANIE4FlHT+Xht8ARESu9HcKeE=",
-          "dev": true
-        }
-      }
-    },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
@@ -3875,12 +3611,6 @@
       "version": "0.2.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "ramda": {
@@ -4022,24 +3752,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "redent": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-      "dev": true,
-      "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        }
       }
     },
     "regenerator-runtime": {
@@ -4258,15 +3970,6 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -4379,12 +4082,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
@@ -4562,12 +4259,6 @@
       "requires": {
         "punycode": "^1.4.1"
       }
-    },
-    "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
@@ -4808,48 +4499,6 @@
             "minimist": "0.0.8"
           }
         }
-      }
-    },
-    "write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "write-json-file": {
-      "version": "2.3.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/write-json-file/-/write-json-file-2.3.0.tgz",
-      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "dev": true,
-      "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,12 @@
         "commander": "^2.11.0"
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -271,6 +277,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
@@ -449,6 +461,23 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -681,6 +710,15 @@
         "which": "^1.2.9"
       }
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "cypress": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.0.tgz",
@@ -765,6 +803,30 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -820,6 +882,12 @@
       "version": "1.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
     "doctrine": {
@@ -2334,6 +2402,12 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/is-promise/-/is-promise-2.1.0.tgz",
@@ -3032,6 +3106,12 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.mapkeys": {
+      "version": "4.6.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
+      "integrity": "sha1-3yz6Ix18V8eorQA6va1dc9PqUZU=",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -3064,6 +3144,125 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha1-38c9Y6mvxxSl43F2DrXIi5EHiqQ=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        }
       }
     },
     "merge-stream": {
@@ -3123,6 +3322,16 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "mkdirp": {
       "version": "0.5.0",
@@ -3495,6 +3704,61 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pinst": {
+      "version": "1.1.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pinst/-/pinst-1.1.1.tgz",
+      "integrity": "sha1-1aE5YR5TzpeFJdi2qjX++h97JgE=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^5.0.0",
+        "lodash.mapkeys": "^4.6.0",
+        "meow": "^5.0.0",
+        "write-json-file": "^2.3.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha1-jY/cc5d8sEEEchy1NmbBymTNMos=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha1-TTweAfocA+p4pgrHr5MsnOU0A/M=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha1-Y9ANIE4FlHT+Xht8ARESu9HcKeE=",
+          "dev": true
+        }
+      }
+    },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
@@ -3611,6 +3875,12 @@
       "version": "0.2.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "ramda": {
@@ -3752,6 +4022,24 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
       }
     },
     "regenerator-runtime": {
@@ -3970,6 +4258,15 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -4082,6 +4379,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
@@ -4259,6 +4562,12 @@
       "requires": {
         "punycode": "^1.4.1"
       }
+    },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
@@ -4499,6 +4808,48 @@
             "minimist": "0.0.8"
           }
         }
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "write-json-file": {
+      "version": "2.3.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+      "dev": true,
+      "requires": {
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "10.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
+    "postinstall": "npm install --prefix example",
     "eslint": "eslint *.js",
     "pretest": "cd example && npm run start &",
     "test": "eslint index.js && cypress run",
@@ -50,6 +51,7 @@
     "http-server": "^0.11.1",
     "husky": "^3.0.0",
     "lint-staged": "^9.0.0",
+    "pinst": "^1.1.1",
     "prettier": "^1.15.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm install --prefix example",
+    "prepare": "npm install --prefix example",
     "eslint": "eslint *.js",
     "pretest": "cd example && npm run start &",
     "test": "eslint index.js && cypress run",
@@ -51,7 +51,6 @@
     "http-server": "^0.11.1",
     "husky": "^3.0.0",
     "lint-staged": "^9.0.0",
-    "pinst": "^1.1.1",
     "prettier": "^1.15.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
Makes it easier to run the tests since you don't need to manually install the example dir (which I didn't know you needed to do at first).

Husky uses this same package so figured it was safe to use here as we use husky.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen