### PR TITLE
chore: stop server after tests have completed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-cache-{{ checksum "package-lock.json" }
+            - v2-cache-{{ checksum "package-lock.json" }}
       - restore_cache:
           keys:
             - v2-example-cache-{{ checksum "example/package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             - v2-cache-{{ checksum "package-lock.json" }}
       # Install package dependencies.
       - run: npm install
+      - run: npm run install:example
       - save_cache:
           key: v2-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@ jobs:
       - restore_cache:
           keys:
             - v2-cache-{{ checksum "package-lock.json" }}
-      - restore_cache:
-          keys:
-            - v2-example-cache-{{ checksum "example/package.json" }}
       # Install package dependencies.
       - run: npm install
       - save_cache:
@@ -26,10 +23,6 @@ jobs:
             - node_modules
             - example/node_modules
             - ~/.cache
-      - save_cache:
-          key: v2-cache-example-{{ checksum "package-lock.json" }}
-          paths:
-            - example/node_modules
 
   # Run the test suite.
   test:
@@ -39,9 +32,6 @@ jobs:
       - restore_cache:
           keys:
             - v2-cache-{{ checksum "package-lock.json" }}
-      - restore_cache:
-          keys:
-            - v2-cache-example-{{ checksum "package-lock.json" }}
       - run: npm run test
 
   # Release a new version.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-cache-{{ checksum "package-lock.json" }}
+            - v3-cache-{{ checksum "package-lock.json" }}
       # Install package dependencies.
       - run: npm install
       - run: npm run install:example
       - save_cache:
-          key: v2-cache-{{ checksum "package-lock.json" }}
+          key: v3-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
             - example/node_modules
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-cache-{{ checksum "package-lock.json" }}
+            - v3-cache-{{ checksum "package-lock.json" }}
       - run: npm run test
 
   # Release a new version.
@@ -43,7 +43,7 @@ jobs:
       - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
       - restore_cache:
           keys:
-            - v2-cache-{{ checksum "package-lock.json" }}
+            - v3-cache-{{ checksum "package-lock.json" }}
       - run: npm publish
   github_release:
     docker:

--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "prestart": "npm run build",
     "start": "http-server -u localhost -p 8080",
     "build": "browserify src/example.js --outfile dist/bundle.js"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prestart": "npm run build",
     "start": "http-server -u localhost -p 8080",
     "build": "browserify src/example.js --outfile dist/bundle.js"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -831,6 +831,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1289,6 +1295,21 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
@@ -1562,6 +1583,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs-extra": {
       "version": "4.0.1",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fs-extra/-/fs-extra-4.0.1.tgz",
@@ -1746,6 +1773,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha1-D3+icKHK/rNkpLLd+qM/hk5BV9o=",
       "dev": true
     },
     "hosted-git-info": {
@@ -2379,6 +2412,23 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha1-WTEKAhkxqfsGu7UeFVzgs/I2gyw=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+          "dev": true
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/isexe/-/isexe-2.0.0.tgz",
@@ -2400,6 +2450,17 @@
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha1-z9hev+Z+ihkAQyQAtNA7vZP7h58=",
+      "dev": true,
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -3066,6 +3127,12 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3456,6 +3523,15 @@
         "pify": "^2.0.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/pend/-/pend-1.2.0.tgz",
@@ -3584,6 +3660,21 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha1-XnQluJUIc2zdTyIk0Cj3uz9yLr0=",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
+    },
+    "psl": {
+      "version": "1.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha1-3xK1sbOjD1HDKerL3vmPOm4TbcY=",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -3888,6 +3979,12 @@
       "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
       "dev": true
     },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
+    },
     "rxjs": {
       "version": "5.5.12",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
@@ -3991,6 +4088,15 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4012,6 +4118,77 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "start-server-and-test": {
+      "version": "1.9.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/start-server-and-test/-/start-server-and-test-1.9.1.tgz",
+      "integrity": "sha1-QB/PhpwqELfSJKbvLPw44qaZVKI=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.5",
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "execa": "0.11.0",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.2.0",
+        "wait-on": "3.2.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.5",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "0.11.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/execa/-/execa-0.11.0.tgz",
+          "integrity": "sha1-Czxx2vm5FZwlKoY82YGvG0QQ2Xo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
       }
     },
     "stream-to-observable": {
@@ -4251,6 +4428,23 @@
         "is-number": "^7.0.0"
       }
     },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha1-1aZ/suaTB+vusIQC7Coqb1962Vw=",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha1-c7fTOVLgH+J6OLBFcpS3ndjaJCw=",
+          "dev": true
+        }
+      }
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -4403,6 +4597,99 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "wait-on": {
+      "version": "3.2.0",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/wait-on/-/wait-on-3.2.0.tgz",
+      "integrity": "sha1-yDkk3w/EKmdcZ4MkxJx2nTeLy4U=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "joi": "^13.0.0",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0",
+        "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/request/-/request-2.88.0.tgz",
+          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm install --prefix example",
+    "prepare": "npm install --prefix example && cd example && npm run build",
     "eslint": "eslint *.js",
-    "pretest": "cd example && npm run start &",
-    "test": "eslint index.js && cypress run",
+    "test": "eslint index.js && start-server-and-test start-server http://localhost:8080 test:run",
+    "start-server": "cd example && npm run start",
+    "test:run": "cypress run",
     "test:debug": "cypress open",
     "fmt": "prettier --write *.{js,json,md} example/*.json example/src/*.{js,css} cypress/**/*.{js,json}"
   },
@@ -53,7 +54,8 @@
     "lint-staged": "^9.0.0",
     "prettier": "^1.15.3",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "start-server-and-test": "^1.9.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm install --prefix example",
+    "prepare": "cd example && npm install",
     "eslint": "eslint *.js",
     "test": "eslint index.js && start-server-and-test start-server http://localhost:8080 test:run",
     "start-server": "cd example && npm run start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm install --prefix example && cd example && npm run build",
+    "prepare": "npm install --prefix example",
     "eslint": "eslint *.js",
     "test": "eslint index.js && start-server-and-test start-server http://localhost:8080 test:run",
     "start-server": "cd example && npm run start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "index.js",
   "scripts": {
-    "prepare": "cd example && npm install",
+    "prepare": "npm run install:example",
+    "install:example": "cd example && npm install",
     "eslint": "eslint *.js",
     "test": "eslint index.js && start-server-and-test start-server http://localhost:8080 test:run",
     "start-server": "cd example && npm run start",


### PR DESCRIPTION
When running `npm test`, the tests would run but leave the `http-server` running. Running `npm test` again would exit as the server would already be in use, preventing tests from being run. Would have to manually stop the server and then could run tests again.

This fixes that by using `start-server-and-test` to stop the server once the tests have completed.

Also had to fix a few circleci issues: broken cache key, a not needed cache, and that it couldn't run the `prepare` script for some reason (so I had to run it manually in circleci).

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen