### PR TITLE
perf: add "sideEffects" flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "author": "Dylan Barrell (dylan@barrell.com)",
   "license": "MPL-2.0",
+  "sideEffects": false,
   "dependencies": {
     "axe-core": "^3.3.2",
     "requestidlecallback": "^0.3.0"


### PR DESCRIPTION
Adds the "sideEffects" flag to `package.json`.

I tested this on my local create-react-app project and it works correctly.

Before:
![image](https://user-images.githubusercontent.com/5382443/64533367-98a06a80-d313-11e9-94b7-afe324b6ace6.png)


After:
![image](https://user-images.githubusercontent.com/5382443/64533372-9e964b80-d313-11e9-892f-d10f0e5c7b24.png)


Closes issue: #114

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
