### PR TITLE
fix(debounce): make 3rd parameter a true debounce

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,27 @@ var components = {};
 var nodes = [document.documentElement];
 var cache = {};
 
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+// @see https://davidwalsh.name/javascript-debounce-function
+function debounce(func, wait, immediate) {
+  var _timeout;
+  return function() {
+    var context = this,
+      args = arguments;
+    var later = function() {
+      _timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !_timeout;
+    clearTimeout(_timeout);
+    _timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}
+
 function getPath(node) {
   var path = [node];
   while (node && node.nodeName.toLowerCase() !== 'html') {
@@ -219,8 +240,9 @@ function checkNode(component) {
 }
 
 function componentAfterRender(component) {
-  after(component, 'componentDidMount', checkNode);
-  after(component, 'componentDidUpdate', checkNode);
+  var debounceCheckNode = debounce(checkNode, timeout);
+  after(component, 'componentDidMount', debounceCheckNode);
+  after(component, 'componentDidUpdate', debounceCheckNode);
 }
 
 function addComponent(component) {

--- a/index.js
+++ b/index.js
@@ -32,16 +32,16 @@ var cache = {};
 function debounce(func, wait, immediate) {
   var _timeout;
   return function() {
-    var context = this,
+    var _context = this,
       args = arguments;
     var later = function() {
       _timeout = null;
-      if (!immediate) func.apply(context, args);
+      if (!immediate) func.apply(_context, args);
     };
     var callNow = immediate && !_timeout;
     clearTimeout(_timeout);
     _timeout = setTimeout(later, wait);
-    if (callNow) func.apply(context, args);
+    if (callNow) func.apply(_context, args);
   };
 }
 


### PR DESCRIPTION
So looking into the code I noticed that the 3rd parameter was touted as a [debounce timeout](https://github.com/dequelabs/react-axe#debouncing)
 but it wasn't really that at all. Instead, it was being passed as an option to the [requestIdleCallback](https://github.com/dequelabs/react-axe/blob/develop/index.js#L125) function, which isn't a debounce but a timeout to [force a run on the next idle cycle](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback). This is why no matter what the value was, react-axe would continue to fire on every `componentDidUpdate` event causing massive performance problems (See #132, #120, and #116).

Using the config:

```js
if (process.env.NODE_ENV !== 'production') {
  axe(React, ReactDOM, 1000, axeConf);
}
```

Shows that even though the config to react-axe uses 1000 ms, `axe.run` is fired every frame.

<img width="1201" alt="Screen Shot 2020-02-13 at 3 06 04 PM" src="https://user-images.githubusercontent.com/2433219/74483323-7d61fa00-4e73-11ea-8ac0-9a6d56dadde4.png">

To fix this I implemented a true debounce to the `componentDidUpdate` call that will respect the user provided value. This greatly improves the performance of app as now `axe.run` is only called after the debounce time.

<img width="1203" alt="Screen Shot 2020-02-13 at 3 06 43 PM" src="https://user-images.githubusercontent.com/2433219/74483395-a3879a00-4e73-11ea-8878-56169372e48d.png">

We can discuss if we want react-axe to fire on the leading edge or the trailing edge (which is where it is currently).

Closes issue: #132, #120, and #116

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
