### PR TITLE
feat: allow consumers to only pass the required function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Call the exported function passing in the React and ReactDOM objects as well as 
 
 ```js
 var React = require('react');
-var ReactDOM = require('react-dom');
+var { findDOMNode } = require('react-dom');
 
 if (process.env.NODE_ENV !== 'production') {
   var axe = require('react-axe');
-  axe(React, ReactDOM, 1000);
+  axe(React, findDOMNode, 1000);
 }
 ```
 

--- a/cypress/integration/index-test.js
+++ b/cypress/integration/index-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { findDOMNode } from 'react-dom';
 
 const axe = require('../../index');
 
@@ -27,7 +27,7 @@ describe('React-axe', function() {
       cy.spy(win.console, 'groupCollapsed');
       cy.spy(win.console, 'groupEnd');
 
-      axe(React, ReactDOM, 0).then(function() {
+      axe(React, findDOMNode, 0).then(function() {
         expect(win.console.group).to.be.calledWith(
           '%cNew aXe issues',
           'color:red;font-weight:normal;'
@@ -51,7 +51,7 @@ describe('React-axe', function() {
           serviceChooser = node[0];
         });
 
-      axe(React, ReactDOM, 0).then(function() {
+      axe(React, findDOMNode, 0).then(function() {
         expect(filterLogs(groupCollapsed.args, colorMessage)).to.equal(
           colorMessage
         );

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -1,6 +1,6 @@
 import 'webcomponents.js/webcomponents.min.js';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { findDOMNode, render } from 'react-dom';
 
 var GlobalHeader = require('./globalHeader');
 var ServiceChooser = require('./serviceChooser');
@@ -18,7 +18,7 @@ var axeConf = {
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  axe(React, ReactDOM, 1000, axeConf);
+  axe(React, findDOMNode, 1000, axeConf);
 }
 
 var services = [
@@ -33,7 +33,7 @@ var services = [
 document.addEventListener('DOMContentLoaded', function() {
   const mountNode = document.querySelector('#container');
   mountNode &&
-    ReactDOM.render(
+    render(
       <div>
         <GlobalHeader />
         <ServiceChooser items={services} />

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var requestIdleCallback = rIC.request;
 var cancelIdleCallback = rIC.cancel;
 
 var React = undefined;
-var ReactDOM = undefined;
+var ReactDOMFindDOMNode = undefined;
 
 var boldCourier = 'font-weight:bold;font-family:Courier;';
 var critical = 'color:red;font-weight:bold;';
@@ -222,7 +222,7 @@ function checkNode(component) {
   var node = null;
 
   try {
-    node = ReactDOM.findDOMNode(component);
+    node = ReactDOMFindDOMNode(component);
   } catch (e) {
     console.group('%caXe error: could not check node', critical);
     console.group('%cComponent', serious);
@@ -263,9 +263,15 @@ function addComponent(component) {
   }
 }
 
-var reactAxe = function reactAxe(_React, _ReactDOM, _timeout, conf, _context) {
+var reactAxe = function reactAxe(
+  _React,
+  _ReactDOMFindDOMNode,
+  _timeout,
+  conf,
+  _context
+) {
   React = _React;
-  ReactDOM = _ReactDOM;
+  ReactDOMFindDOMNode = _ReactDOMFindDOMNode;
   timeout = _timeout;
   context = _context;
 


### PR DESCRIPTION
Instead of passing the whole `ReactDOM` object. Only pass the required function, for this library it's `domFindNode`.

This will help with tree shaking

Closes issue: #139 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
