### PR TITLE
fix: 4.5:1 ratio for devtool colors in both light and dark theme

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,12 +9,31 @@ const cancelIdleCallback = rIC.cancel;
 let React;
 let ReactDOM;
 
+// contrasted against Chrome default color of #ffffff
+const lightTheme = {
+  serious: '#d93251',
+  minor: '#d24700',
+  text: 'black'
+};
+
+// contrasted against Safari dark mode color of #535353
+const darkTheme = {
+  serious: '#ffb3b3',
+  minor: '#ffd500',
+  text: 'white'
+};
+
+let theme =
+  window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? darkTheme
+    : lightTheme;
+
 const boldCourier = 'font-weight:bold;font-family:Courier;';
-const critical = 'color:red;font-weight:bold;';
-const serious = 'color:red;font-weight:normal;';
-const moderate = 'color:orange;font-weight:bold;';
-const minor = 'color:orange;font-weight:normal;';
-const defaultReset = 'font-color:black;font-weight:normal;';
+const critical = `color:${theme.serious};font-weight:bold;`;
+const serious = `color:${theme.serious};font-weight:normal;`;
+const moderate = `color:${theme.minor};font-weight:bold;`;
+const minor = `color:${theme.minor};font-weight:normal;`;
+const defaultReset = `font-color:${theme.text};font-weight:normal;`;
 
 let idleId: number | undefined;
 let timeout: number;

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ const darkTheme = {
   text: 'white'
 };
 
-let theme =
+const theme =
   window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
     ? darkTheme
     : lightTheme;


### PR DESCRIPTION
Making our devtools color-contrast compliant. #112 pointed out that it would be a problem for either theme if we changed the colors, but I address this here by providing two themes and detecting which one to use.

Closes issue: #108, #112

Light Theme:
![image](https://user-images.githubusercontent.com/2433219/75828453-1ac09780-5d69-11ea-880d-f67537cf247a.png)

Dark Theme:
![image](https://user-images.githubusercontent.com/2433219/75828495-31ff8500-5d69-11ea-85a8-b73ead66cafa.png)

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
