### PR TITLE
fix: Fire debounced checkNode on leading edge

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -300,7 +300,7 @@ function checkNode(component: React.Component): void {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function componentAfterRender(component: any): void {
-  const debounceCheckNode: Function = debounce(checkNode, timeout);
+  const debounceCheckNode: Function = debounce(checkNode, timeout, true);
   after(component, 'componentDidMount', debounceCheckNode);
   after(component, 'componentDidUpdate', debounceCheckNode);
 }


### PR DESCRIPTION
Taken from @dambusm's [fork](https://github.com/dambusm/react-axe/commit/63cbf0fa1dda51250c5925143fef64ca252ddb7e)

This PR fixes issues with checking unmounted nodes and the resulting console errors.

Example console error:
![image](https://user-images.githubusercontent.com/4871708/83808536-7a01b100-a6a4-11ea-823c-7b4eeb8a939d.png)

Closes issue: #144 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
