### PR TITLE
chore: adding dist folder in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-	"files": [
+  "files": [
     "/dist"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+	"files": [
+    "/dist"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build && npm run install:example",


### PR DESCRIPTION
When upgrading to `3.5.0`, we could not bundle `react-axe` as the `dist` folder was missing in the `package.json` file. All our project was able to use was the typescript code, and it would just make our CI fail.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
