### PR TITLE
fix(build): don't ignore dist direcotry

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.circleci
+.github
+cypress
+node_modules
+.editorconfig
+.eslintrc.js
+cypress.json
+tsconfig.json


### PR DESCRIPTION
An additional fix to ensure we publish the `dist` directory. Also ignore files from npm we don't need to publish.

Closes issue: #153 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
