### PR TITLE
chore: Revert "fix: explicitly include dist files in npm tarball"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/after.js",
-    "dist/after.d.ts",
-    "dist/after.js.map",
-    "dist/index.js",
-    "dist/index.d.ts",
-    "dist/index.js.map"
+    "/dist"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Reverts dequelabs/react-axe#158

Using `/dist` is fine. There's something else going wrong here.