### PR TITLE
Release 3.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,9 @@ jobs:
       - restore_cache:
           keys:
             - v4-cache-{{ checksum "package-lock.json" }}
+      - run: npx tsc
       - run: npm publish
+
   github_release:
     docker:
       - image: circleci/golang:1.10
@@ -69,6 +71,8 @@ jobs:
         - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
         - run: npm whoami
         - run: .circleci/canary-version.js
+        # For an unknown reason, `npm run build` is failing with "cannot run in wd ", which prevents the `dist/` files from being emitted. This ensures the files are there before trying to publish.
+        - run: npx tsc
         - run: npm publish --tag=next
 
 workflows:

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ node_modules
 .eslintrc.js
 cypress.json
 tsconfig.json
+!dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.5.2](https://github.com/dequelabs/react-axe/compare/v3.5.1...v3.5.2) (2020-06-19)
+
 ### [3.5.1](https://github.com/dequelabs/react-axe/compare/v3.5.0...v3.5.1) (2020-06-19)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-axe",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-axe",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/after.js",
+    "dist/after.d.ts",
+    "dist/after.js.map",
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/index.js.map"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,6 @@
   "description": "Dynamic accessibility analysis for React using axe-core",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist/after.js",
-    "dist/after.d.ts",
-    "dist/after.js.map",
-    "dist/index.js",
-    "dist/index.d.ts",
-    "dist/index.js.map"
-  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build && npm run install:example",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare": "npm run build && npm run install:example",
+    "prepare": "npm run build",
     "install:example": "cd example && npm install",
     "eslint": "eslint --ext .js,.ts *.ts",
+    "pretest": "npm run install:example",
     "test": "eslint index.ts && tsc && start-server-and-test start-server http://localhost:8080 test:run",
     "start-server": "cd example && npm run start",
     "test:run": "cypress run",


### PR DESCRIPTION
This was shown to work in the canary build (finally). We have no idea why the release script was not able to run the `npm build` script before publishing.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
